### PR TITLE
Add Apereo-incubating badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Learning Analytics Processor
 =======
 An open source, Java-based analytics workflow manager. Find detailed documentation on our [github.io site](http://apereo-learning-analytics-initiative.github.io/LearningAnalyticsProcessor/).
 
+[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
+
 *************************************************************************************
 
 License


### PR DESCRIPTION
Add badge highlighting that Apereo incubating.

[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)

[A better badge may become feasible](https://groups.google.com/a/apereo.org/d/topic/incubation/p2h2ypnATO0/discussion).

In the meantime, this changeset makes progress, with a pretty-good badge linking back to the incubating projects listing.